### PR TITLE
update subcommand list to fix build error

### DIFF
--- a/src/main/java/com/hackclub/hccore/commands/LocCommand.java
+++ b/src/main/java/com/hackclub/hccore/commands/LocCommand.java
@@ -13,7 +13,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.entity.Player;
-import org.bukkit.util.StringUtil;;
+import org.bukkit.util.StringUtil;
 
 public class LocCommand implements TabExecutor {
     private final HCCorePlugin plugin;


### PR DESCRIPTION
change from List.of to Arrays.asList, which allows a mutable list and prevents NullPointerExceptions