### PR TITLE
Allow non-op players to run /tps

### DIFF
--- a/src/main/java/com/hackclub/hccore/DataManager.java
+++ b/src/main/java/com/hackclub/hccore/DataManager.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
 
@@ -32,12 +33,19 @@ public class DataManager {
     public void registerPlayer(Player player) {
         this.players.put(player.getUniqueId(), new PlayerData(this.plugin, player));
 
+        // Register custom permissions
+        PermissionAttachment attachment = player.addAttachment(this.plugin);
+        this.getData(player).setAttachment(attachment);
+        attachment.setPermission("bukkit.command.tps", true);
+        player.updateCommands();
+
         // Register player's team
         Scoreboard mainScoreboard =
                 this.plugin.getServer().getScoreboardManager().getMainScoreboard();
         player.setScoreboard(mainScoreboard);
         Team playerTeam = mainScoreboard.registerNewTeam(player.getName());
         playerTeam.addEntry(player.getName());
+
         // Load in player data for use
         this.getData(player).load();
     }
@@ -50,7 +58,9 @@ public class DataManager {
 
     public void unregisterPlayer(Player player) {
         this.getData(player).save();
+
         this.getData(player).getTeam().unregister();
+        player.removeAttachment(this.getData(player).getAttachment());
 
         this.players.remove(player.getUniqueId());
     }

--- a/src/main/java/com/hackclub/hccore/PlayerData.java
+++ b/src/main/java/com/hackclub/hccore/PlayerData.java
@@ -12,6 +12,7 @@ import com.hackclub.hccore.utils.gson.GsonUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.scoreboard.Team;
 
 public class PlayerData {
@@ -22,6 +23,7 @@ public class PlayerData {
     // Session data (will be cleared when player quits)
     private boolean isAfk = false;
     private long lastDamagedAt = 0;
+    private PermissionAttachment attachment;
 
     // Persistent data
     @Expose
@@ -62,6 +64,14 @@ public class PlayerData {
 
     public void setLastDamagedAt(long damagedAt) {
         this.lastDamagedAt = damagedAt;
+    }
+
+    public PermissionAttachment getAttachment() {
+        return this.attachment;
+    }
+
+    public void setAttachment(PermissionAttachment attachment) {
+        this.attachment = attachment;
     }
 
     public String getNickname() {


### PR DESCRIPTION
Removes the need for a whole dedicated plugin just to change /tps's permissions.