### PR TITLE
Fix team name in use error when registering player

### DIFF
--- a/src/main/java/com/hackclub/hccore/DataManager.java
+++ b/src/main/java/com/hackclub/hccore/DataManager.java
@@ -43,7 +43,12 @@ public class DataManager {
         Scoreboard mainScoreboard =
                 this.plugin.getServer().getScoreboardManager().getMainScoreboard();
         player.setScoreboard(mainScoreboard);
-        Team playerTeam = mainScoreboard.registerNewTeam(player.getName());
+        // Unregister existing teams in the player's name
+        Team playerTeam = mainScoreboard.getTeam(player.getName());
+        if (playerTeam != null) {
+            playerTeam.unregister();
+        }
+        playerTeam = mainScoreboard.registerNewTeam(player.getName());
         playerTeam.addEntry(player.getName());
 
         // Load in player data for use


### PR DESCRIPTION
Fix IllegalArgumentException that occurs when the team already exists, which led to player data being reset. This scenario only occurs when the plugin doesn't shut down properly and the unregister method isn't called.