### PR TITLE
Reduce damage cooldown to 10 seconds

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,4 +8,4 @@ settings:
     # Radius extending from the world spawn in which the command can be used
     allowed-radius: 2000
     # Time in seconds a player has to wait before being able to use the command again
-    damage-cooldown: 20
+    damage-cooldown: 10


### PR DESCRIPTION
Seeing as how everything counts as damage, even if you don't lose health, it feels like the damage cooldown is a bit too high. 10 seconds is long enough to avoid leaving during combat or danger, but it reduces the amount of pointless time spent waiting around for the cooldown.