### PR TITLE
Use name color in /nick success message

### DIFF
--- a/src/main/java/com/hackclub/hccore/commands/NickCommand.java
+++ b/src/main/java/com/hackclub/hccore/commands/NickCommand.java
@@ -43,9 +43,8 @@ public class NickCommand implements CommandExecutor {
         }
 
         this.plugin.getDataManager().getData(player).setNickname(newNickname);
-        ChatColor nameColor = this.plugin.getDataManager().getData(player).getNameColor();
         sender.sendMessage(ChatColor.GREEN + "Your nickname was set to "
-                + (nameColor != null ? nameColor : ChatColor.AQUA) + newNickname);
+                + this.plugin.getDataManager().getData(player).getNameColor() + newNickname);
 
         return true;
     }

--- a/src/main/java/com/hackclub/hccore/commands/NickCommand.java
+++ b/src/main/java/com/hackclub/hccore/commands/NickCommand.java
@@ -43,8 +43,9 @@ public class NickCommand implements CommandExecutor {
         }
 
         this.plugin.getDataManager().getData(player).setNickname(newNickname);
-        sender.sendMessage(
-                ChatColor.GREEN + "Your nickname was set to " + ChatColor.AQUA + newNickname);
+        ChatColor nameColor = this.plugin.getDataManager().getData(player).getNameColor();
+        sender.sendMessage(ChatColor.GREEN + "Your nickname was set to "
+                + (nameColor != null ? nameColor : ChatColor.AQUA) + newNickname);
 
         return true;
     }


### PR DESCRIPTION
Uses the player's current name color as a default, and aqua as a secondary in the name color isn't set