### PR TITLE
Disallow AFK players from sleeping

### DIFF
--- a/src/main/java/com/hackclub/hccore/listeners/SleepListener.java
+++ b/src/main/java/com/hackclub/hccore/listeners/SleepListener.java
@@ -2,6 +2,7 @@ package com.hackclub.hccore.listeners;
 
 import com.hackclub.hccore.HCCorePlugin;
 import com.hackclub.hccore.PlayerData;
+import com.hackclub.hccore.events.player.PlayerAFKStatusChangeEvent;
 import org.bukkit.ChatColor;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
@@ -29,9 +30,27 @@ public class SleepListener implements Listener {
     }
 
     @EventHandler
+    public void onPlayerAFKStatusChange(final PlayerAFKStatusChangeEvent event) {
+        // Wake the player up if they become AFK while sleeping
+        Player player = event.getPlayer();
+        if (event.getNewValue() && player.isSleeping()) {
+            player.wakeup(true);
+            player.sendMessage(ChatColor.RED + "You can’t sleep while you’re AFK.");
+        }
+    }
+
+    @EventHandler
     public void onPlayerBedEnter(final PlayerBedEnterEvent event) {
         // Ignore unsuccessful attempts to sleep
         if (event.getBedEnterResult() != PlayerBedEnterEvent.BedEnterResult.OK) {
+            return;
+        }
+
+        // Only allow active players to sleep
+        PlayerData data = this.plugin.getDataManager().getData(event.getPlayer());
+        if (data.isAfk()) {
+            event.setCancelled(true);
+            event.getPlayer().sendMessage(ChatColor.RED + "You can’t sleep while you’re AFK.");
             return;
         }
 
@@ -118,7 +137,7 @@ public class SleepListener implements Listener {
                 .scheduleSyncDelayedTask(this.plugin, new Runnable() {
                     @Override
                     public void run() {
-                        if (world.getPlayers().size() == 0) {
+                        if (world.getPlayers().size() == 0 || getSleepingPlayers(world) == 0) {
                             return;
                         }
 


### PR DESCRIPTION
This prevents abuse of /afk by preventing AFK players from sleeping. If a player enters the bed and then runs /afk, they'll be woken up.