### PR TITLE
Fix NPEs in SleepListener on player quit

### DIFF
--- a/src/main/java/com/hackclub/hccore/listeners/AFKListener.java
+++ b/src/main/java/com/hackclub/hccore/listeners/AFKListener.java
@@ -21,6 +21,21 @@ public class AFKListener implements Listener {
     }
 
     @EventHandler
+    public void onPlayerAFKStatusChange(final PlayerAFKStatusChangeEvent event) {
+        Player player = event.getPlayer();
+        PlayerData data = this.plugin.getDataManager().getData(player);
+
+        if (event.getNewValue()) {
+            player.sendTitle(ChatColor.RED + ChatColor.BOLD.toString() + "You are AFK",
+                    "Run /afk to mark yourself as active", 10, 999999, 20);
+            player.getServer().broadcastMessage(data.getUsableName() + " is now AFK");
+        } else {
+            player.sendTitle(null, null, 0, 1, -1);
+            player.getServer().broadcastMessage(data.getUsableName() + " is now active");
+        }
+    }
+
+    @EventHandler
     public void onAsyncPlayerChat(final AsyncPlayerChatEvent event) {
         this.plugin.getDataManager().getData(event.getPlayer())
                 .setLastActiveAt(System.currentTimeMillis());
@@ -50,20 +65,5 @@ public class AFKListener implements Listener {
 
         this.plugin.getDataManager().getData(event.getPlayer())
                 .setLastActiveAt(System.currentTimeMillis());
-    }
-
-    @EventHandler
-    public void onPlayerAFKStatusChange(final PlayerAFKStatusChangeEvent event) {
-        Player player = event.getPlayer();
-        PlayerData data = this.plugin.getDataManager().getData(player);
-
-        if (event.getNewValue()) {
-            player.sendTitle(ChatColor.RED + ChatColor.BOLD.toString() + "You are AFK",
-                    "Run /afk to mark yourself as active", 10, 999999, 20);
-            player.getServer().broadcastMessage(data.getUsableName() + " is now AFK");
-        } else {
-            player.sendTitle(null, null, 0, 1, -1);
-            player.getServer().broadcastMessage(data.getUsableName() + " is now active");
-        }
     }
 }

--- a/src/main/java/com/hackclub/hccore/listeners/PlayerListener.java
+++ b/src/main/java/com/hackclub/hccore/listeners/PlayerListener.java
@@ -5,6 +5,7 @@ import com.hackclub.hccore.PlayerData;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
@@ -57,7 +58,7 @@ public class PlayerListener implements Listener {
                 playerColor + ChatColor.translateAlternateColorCodes('&', event.getMessage()));
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.LOWEST) // Runs foremost
     public void onPlayerJoin(final PlayerJoinEvent event) {
         this.plugin.getDataManager().registerPlayer(event.getPlayer());
         // Set the initial active time
@@ -110,7 +111,7 @@ public class PlayerListener implements Listener {
         this.plugin.getDataManager().getData(event.getPlayer()).setLastDamagedAt(0);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR) // Runs very last
     public void onPlayerQuit(final PlayerQuitEvent event) {
         // NOTE: Title isn't cleared when the player leaves the server
         // event.getPlayer().resetTitle();


### PR DESCRIPTION
Fixes #97. We now prioritize the event handlers responsible for player session registration.