### PR TITLE
Updated build process

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,34 +13,35 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 17
-      uses: actions/setup-java@v2
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    - name: Build with Gradle
-      run: ./gradlew build
-    - name: Upload jar to build artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: HCCore-1.0.0.jar
-        path: build/libs/HCCore-1.0.0.jar
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/master' && github.repository == 'hackclub/HCCore' && github.event_name == 'push'
-    steps:
-    - name: Download jar
-      uses: actions/download-artifact@v2
-      with:
-        name: HCCore-1.0.0.jar
-    - name: Add SSH key
-      run: mkdir $HOME/.ssh && echo "${{ secrets.SSH_PRIVATE_KEY }}" > $HOME/.ssh/id_rsa && chmod 400 $HOME/.ssh/id_rsa && ssh-keyscan -H mc.hackclub.com >> ~/.ssh/known_hosts
-    - name: Copy jar
-      run: scp HCCore-1.0.0.jar minecraft@mc.hackclub.com:/opt/minecraft/server/plugins/HCCore-1.0.0.jar
-    - name: Run reboot script
-      run: ssh minecraft@mc.hackclub.com /opt/minecraft/restart.sh
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew build
+      - name: Upload jar to build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: HCCore.jar
+          path: build/libs/HCCore-Shadow-*.jar
+#  deploy:
+#    runs-on: ubuntu-latest
+#    needs: build
+#    if: github.ref == 'refs/heads/master' && github.repository == 'hackclub/HCCore' && github.event_name == 'push'
+#    steps:
+#    - name: Download jar
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: HCCore-1.0.0.jar
+#    - name: Add SSH key
+#      run: mkdir $HOME/.ssh && echo "${{ secrets.SSH_PRIVATE_KEY }}" > $HOME/.ssh/id_rsa && chmod 400 $HOME/.ssh/id_rsa && ssh-keyscan -H mc.hackclub.com >> ~/.ssh/known_hosts
+#    - name: Copy jar
+#      run: scp HCCore-1.0.0.jar minecraft@mc.hackclub.com:/opt/minecraft/server/plugins/HCCore-1.0.0.jar
+#    - name: Run reboot script
+#      run: ssh minecraft@mc.hackclub.com /opt/minecraft/restart.sh
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,9 +13,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .gradle/
 build/
 bin/
+run/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-  `java-library`
-  id("com.github.johnrengelman.shadow") version "7.1.0"
-  id("io.papermc.paperweight.userdev") version "1.3.0"
+    `java-library`
+    id("com.github.johnrengelman.shadow") version "7.1.0"
+    id("xyz.jpenilla.run-paper") version "2.0.0"
 }
 
 group = "com.hackclub.hccore"
@@ -9,47 +9,53 @@ version = "1.0.0"
 description = "Main plugin for the Hack Club Minecraft server."
 
 java {
-  toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
 }
 
 dependencies {
     implementation("com.github.Trigary:AdvancementCreator:v2.0")
-    implementation("com.google.code.gson:gson:2.8.6")
+    implementation("com.google.code.gson:gson:2.8.9")
     implementation("de.tr7zw:item-nbt-api:2.8.0")
 
-    compileOnly("com.comphenix.protocol:ProtocolLib:4.5.1")
-    paperDevBundle("1.18-R0.1-SNAPSHOT")
+    compileOnly("com.comphenix.protocol:ProtocolLib:5.0.0-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.19.3-R0.1-SNAPSHOT")
 }
 
 tasks {
-  // Run reobfJar on build
-  build {
-    dependsOn(reobfJar)
-  }
+    // Run shadowJar on build
+    build {
+        dependsOn(shadowJar)
+    }
 
-  compileJava {
-    options.encoding = Charsets.UTF_8.name()
-    options.release.set(17)
-  }
+    compileJava {
+        options.encoding = Charsets.UTF_8.name()
+        options.release.set(17)
+        // show deprecation warnings: paper deprecated lots of pure string functions for chat components
+//      options.isDeprecation = true
+    }
 
-  javadoc {
-    options.encoding = Charsets.UTF_8.name()
-  }
+    javadoc {
+        options.encoding = Charsets.UTF_8.name()
+    }
 
-  processResources {
-    filteringCharset = Charsets.UTF_8.name()
-      expand("name" to rootProject.name, "version" to version)
-  }
+    processResources {
+        filteringCharset = Charsets.UTF_8.name()
+        expand("name" to rootProject.name, "version" to version)
+    }
 
-  shadowJar {
-    archiveBaseName.set("HCCore-Shadow")
-    archiveClassifier.set("")
-    archiveVersion.set("")
-  }
+    shadowJar {
+        archiveBaseName.set("HCCore-Shadow")
+        archiveClassifier.set("")
+    }
+
+
+    runServer {
+        minecraftVersion("1.19.3")
+
+    }
 }
 
 repositories {
-    //jcenter()
     mavenCentral()
 
     // AdvancementCreator
@@ -61,5 +67,6 @@ repositories {
     // ProtoLib
     maven("https://repo.dmulloy2.net/nexus/repository/public/")
 
-    mavenLocal()
+    // Papermc
+    maven { url = uri("https://repo.papermc.io/repository/maven-public/") }
 }


### PR DESCRIPTION
removed broken deploy github action
added caching, and publishing of the shaded jar file

added /run to .gitignore, used in runServer
reformatted build.gradle.kts
changed from paperweight, to native "compileonly"
added run-paper, used for a test server in-ide
upgraded google gson
upgraded protocol lib to 1.19.3 snapshots
built plugin against 1.19.3
add version number to output filename