### PR TITLE
Slack ID Linking

### DIFF
--- a/src/main/java/com/hackclub/hccore/DataManager.java
+++ b/src/main/java/com/hackclub/hccore/DataManager.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Predicate;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
@@ -30,6 +31,7 @@ public class DataManager {
   public PlayerData getData(Player player) {
     return this.players.get(player.getUniqueId());
   }
+  public PlayerData getData(OfflinePlayer player) { return this.players.get(player.getUniqueId());}
   public PlayerData findData(Predicate<? super PlayerData> predicate) {
     return this.players.values().stream().filter(predicate).findFirst().orElse(null);
   }

--- a/src/main/java/com/hackclub/hccore/DataManager.java
+++ b/src/main/java/com/hackclub/hccore/DataManager.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Predicate;
 import org.bukkit.entity.Player;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
@@ -28,6 +29,9 @@ public class DataManager {
 
   public PlayerData getData(Player player) {
     return this.players.get(player.getUniqueId());
+  }
+  public PlayerData findData(Predicate<? super PlayerData> predicate) {
+    return this.players.values().stream().filter(predicate).findFirst().orElse(null);
   }
 
   public void registerPlayer(Player player) {

--- a/src/main/java/com/hackclub/hccore/HCCorePlugin.java
+++ b/src/main/java/com/hackclub/hccore/HCCorePlugin.java
@@ -29,6 +29,7 @@ import com.hackclub.hccore.commands.ColorCommand;
 import com.hackclub.hccore.commands.LocCommand;
 import com.hackclub.hccore.commands.NickCommand;
 import com.hackclub.hccore.commands.PingCommand;
+import com.hackclub.hccore.commands.SlackCommand;
 import com.hackclub.hccore.commands.SpawnCommand;
 import com.hackclub.hccore.commands.StatsCommand;
 import com.hackclub.hccore.listeners.AFKListener;
@@ -86,6 +87,7 @@ public class HCCorePlugin extends JavaPlugin {
     registerCommand("loc", new LocCommand(this));
     registerCommand("nick", new NickCommand(this));
     registerCommand("ping", new PingCommand(this));
+    registerCommand("slack", new SlackCommand(this));
     registerCommand("spawn", new SpawnCommand(this));
     registerCommand("stats", new StatsCommand(this));
 
@@ -147,6 +149,10 @@ public class HCCorePlugin extends JavaPlugin {
 
   public ProtocolManager getProtocolManager() {
     return this.protocolManager;
+  }
+
+  public SlackBot getSlackBot() {
+    return this.bot;
   }
 
   public AdvancementTab advancementTab;

--- a/src/main/java/com/hackclub/hccore/commands/SlackCommand.java
+++ b/src/main/java/com/hackclub/hccore/commands/SlackCommand.java
@@ -1,0 +1,90 @@
+package com.hackclub.hccore.commands;
+
+import com.hackclub.hccore.HCCorePlugin;
+import com.hackclub.hccore.PlayerData;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.entity.Player;
+import org.bukkit.util.StringUtil;
+import org.jetbrains.annotations.NotNull;
+
+public class SlackCommand implements TabExecutor {
+
+  private final HCCorePlugin plugin;
+
+  public SlackCommand(HCCorePlugin plugin) {
+    this.plugin = plugin;
+  }
+
+  @Override
+  public boolean onCommand(@NotNull CommandSender sender, @NotNull Command cmd,
+      @NotNull String alias, String[] args) {
+    if (!(sender instanceof Player player)) {
+      sender.sendMessage(
+          Component.text("You must be a player to use this").color(NamedTextColor.RED));
+      return true;
+    }
+
+    if (args.length == 0) {
+      return false;
+    }
+
+    if (args[0].equals("link")) {
+      if (args.length != 2) {
+        return false;
+      }
+
+      try {
+        if (!this.plugin.getSlackBot().isUserIdValid(args[1])) {
+          player.sendMessage(Component.text("That Slack ID is invalid!").color(NamedTextColor.RED));
+          return true;
+        }
+
+        this.plugin.getSlackBot().sendVerificationMessage(args[1], player.getName());
+
+        player.sendMessage(
+            Component.text("A verification message has been sent to your Slack account")
+                .color(NamedTextColor.GREEN));
+      } catch (IOException e) {
+        player.sendMessage(Component.text("An error occurred while linking your account")
+            .color(NamedTextColor.RED));
+        return true;
+      }
+
+      return true;
+    } else if (args[0].equals("unlink")) {
+      PlayerData playerData = this.plugin.getDataManager().getData(player);
+      playerData.setSlackId(null);
+      player.sendMessage(
+          Component.text("Your Slack account has been unlinked").color(NamedTextColor.GREEN));
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command cmd,
+      @NotNull String alias, String[] args) {
+    if (!(sender instanceof Player)) {
+      return null;
+    }
+
+    List<String> completions = new ArrayList<>();
+    if (args.length == 1) {
+        List<String> subcommands = Arrays.asList("link", "unlink");
+        StringUtil.copyPartialMatches(args[0], subcommands, completions);
+    }
+
+    Collections.sort(completions);
+    return completions;
+  }
+}

--- a/src/main/java/com/hackclub/hccore/slack/SlackBot.java
+++ b/src/main/java/com/hackclub/hccore/slack/SlackBot.java
@@ -247,7 +247,7 @@ public class SlackBot implements Listener {
               return 1;
             })).executes(context -> {
               try {
-                context.getSource().getContext().respond("Missing argument: mention");
+                context.getSource().getContext().respond("Missing argument: slack user mention or id");
               } catch (IOException e) {
                 e.printStackTrace();
               }

--- a/src/main/java/com/hackclub/hccore/slack/SlackBot.java
+++ b/src/main/java/com/hackclub/hccore/slack/SlackBot.java
@@ -215,6 +215,8 @@ public class SlackBot implements Listener {
                 StringArgumentType.greedyString()).executes(context -> {
               String mention = StringArgumentType.getString(context, "mention");
               String id;
+
+              // User mention
               if (mention.startsWith("<@") && mention.endsWith(">")) {
                 int pipeIdx = mention.indexOf('|');
                 if (pipeIdx == -1) {
@@ -223,12 +225,8 @@ public class SlackBot implements Listener {
                   id = mention.substring(2, pipeIdx);
                 }
               } else {
-                try {
-                  context.getSource().getContext().respond("Invalid user mention");
-                } catch (IOException e) {
-                  e.printStackTrace();
-                }
-                return 1;
+                // Try user id
+                id = mention;
               }
 
               try {

--- a/src/main/java/com/hackclub/hccore/slack/SlackBot.java
+++ b/src/main/java/com/hackclub/hccore/slack/SlackBot.java
@@ -25,6 +25,7 @@ import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.response.chat.ChatPostMessageResponse;
 import com.slack.api.methods.response.users.profile.UsersProfileGetResponse;
+import com.slack.api.model.User;
 import com.slack.api.model.event.MessageBotEvent;
 import com.slack.api.model.event.MessageChannelJoinEvent;
 import com.slack.api.model.event.MessageDeletedEvent;
@@ -378,15 +379,14 @@ public class SlackBot implements Listener {
     return appToken;
   }
 
-  public boolean isUserIdValid(String id) throws IOException {
+  public User getUserInfo(String id) throws IOException {
     MethodsClient client = Slack.getInstance().methods();
     try {
       var res = client.usersInfo(r -> r.token(getBotToken()).user(id));
 
-      return res.isOk();
+      return res.getUser();
     } catch (SlackApiException e) {
-      e.printStackTrace();
-      return false;
+      return null;
     }
   }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -30,7 +30,7 @@ commands:
     usage: /ping [player]
   slack:
     description: Manage the HackCraft Slack integration
-    usage: /slack <link|unlink> [id]
+    usage: /slack <link|unlink|lookup> [id|payer]
   spawn:
     description: Teleports you to the world’s spawn location
     usage: /spawn

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -30,7 +30,7 @@ commands:
     usage: /ping [player]
   slack:
     description: Manage the HackCraft Slack integration
-    usage: /slack <link|unlink|lookup> [id|payer]
+    usage: /slack <(link <slackId>) | unlink | (lookup <player>)>
   spawn:
     description: Teleports you to the world’s spawn location
     usage: /spawn

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -28,6 +28,9 @@ commands:
   ping:
     description: Gets the ping of you or a specified player
     usage: /ping [player]
+  slack:
+    description: Manage the HackCraft Slack integration
+    usage: /slack <link|unlink> [id]
   spawn:
     description: Teleports you to the world’s spawn location
     usage: /spawn


### PR DESCRIPTION
This PR allows players to link their Minecraft user to their Slack user. It also adds two commands, one in Minecraft for looking up someone's slack username, and one in Slack for looking up someone's Minecraft username.

Need to add `users:read` scope to Slack application
