### PR TITLE
Require slack link to join server and implement code linking

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:1.19")
     implementation("org.slf4j:slf4j-simple:2.0.5")
     implementation("org.apache.commons:commons-text:1.10.0")
+    implementation("org.apache.commons:commons-collections4:4.4")
 
     compileOnly("com.frengor:ultimateadvancementapi:2.2.3")
     compileOnly("com.comphenix.protocol:ProtocolLib:5.0.0-SNAPSHOT")

--- a/src/main/java/com/hackclub/hccore/DataManager.java
+++ b/src/main/java/com/hackclub/hccore/DataManager.java
@@ -14,7 +14,7 @@ public class DataManager {
 
   private final HCCorePlugin plugin;
   private final String dataFolder;
-  private final Map<UUID, PlayerData> players = new HashMap<>();
+  private final Map<UUID, PlayerData> onlinePlayers = new HashMap<>();
 
   public DataManager(HCCorePlugin plugin) {
     this.plugin = plugin;
@@ -29,15 +29,23 @@ public class DataManager {
   }
 
   public PlayerData getData(Player player) {
-    return this.players.get(player.getUniqueId());
+    return this.onlinePlayers.get(player.getUniqueId());
   }
-  public PlayerData getData(OfflinePlayer player) { return this.players.get(player.getUniqueId());}
+  public PlayerData getData(OfflinePlayer offlinePlayer) {
+    PlayerData data = this.onlinePlayers.get(offlinePlayer.getUniqueId());
+
+    if (data == null) {
+      data = new PlayerData(this.plugin, offlinePlayer);
+    }
+
+    return data;
+  }
   public PlayerData findData(Predicate<? super PlayerData> predicate) {
-    return this.players.values().stream().filter(predicate).findFirst().orElse(null);
+    return this.onlinePlayers.values().stream().filter(predicate).findFirst().orElse(null);
   }
 
   public void registerPlayer(Player player) {
-    this.players.put(player.getUniqueId(), new PlayerData(this.plugin, player));
+    this.onlinePlayers.put(player.getUniqueId(), new PlayerData(this.plugin, player));
 
     // Register player's team
     Scoreboard mainScoreboard = player.getServer().getScoreboardManager().getMainScoreboard();
@@ -65,7 +73,7 @@ public class DataManager {
 
     this.getData(player).getTeam().unregister();
 
-    this.players.remove(player.getUniqueId());
+    this.onlinePlayers.remove(player.getUniqueId());
   }
 
   public void unregisterAll() {

--- a/src/main/java/com/hackclub/hccore/PlayerData.java
+++ b/src/main/java/com/hackclub/hccore/PlayerData.java
@@ -65,15 +65,15 @@ public class PlayerData {
   }
 
   public void setAfk(boolean afk) {
-    this.isAfk = afk;
-    this.updateDisplayedName();
-
-    TextColor newColor = afk ? NamedTextColor.GRAY : this.getNameColor();
-    String newSuffix = afk ? " (AFK)" : "";
-    this.getTeam().color(NamedTextColor.nearestTo(newColor));
-    this.getTeam().suffix(Component.text(newSuffix).color(newColor));
-
     if (this.player != null) {
+      this.isAfk = afk;
+      this.updateDisplayedName();
+
+      TextColor newColor = afk ? NamedTextColor.GRAY : this.getNameColor();
+      String newSuffix = afk ? " (AFK)" : "";
+      this.getTeam().color(NamedTextColor.nearestTo(newColor));
+      this.getTeam().suffix(Component.text(newSuffix).color(newColor));
+
       Event event = new PlayerAFKStatusChangeEvent(this.player, afk);
       this.player.getServer().getPluginManager().callEvent(event);
     }

--- a/src/main/java/com/hackclub/hccore/listeners/PlayerListener.java
+++ b/src/main/java/com/hackclub/hccore/listeners/PlayerListener.java
@@ -98,16 +98,26 @@ public class PlayerListener implements Listener {
     this.plugin.getDataManager().registerPlayer(player);
     PlayerData data = this.plugin.getDataManager().getData(player);
 
-    // Check for slack link
-    if (data == null || data.getSlackId() == null) {
-      this.plugin.getLogger().info("Kicking " + player.getName() + " because they are not linked");
-      String code = this.plugin.getSlackBot().generateVerificationCode(player.getUniqueId().toString());
-      player.kick(text("You must link your Slack account to join the server!").color(RED)
-          .decorate(BOLD).appendNewline().appendNewline().append(
-              text("Please run ").color(NamedTextColor.WHITE)
-                  .append(text("/" + this.plugin.getConfig().get("settings.slack-link.base-command", "minecraft") + " link " + code).color(NamedTextColor.GOLD))
-                  .append(text(" in the #minecraft channel in the Slack (https://slack.hackclub.com) to link your account.")).color(NamedTextColor.WHITE)));
-      return;
+    // Check if slack link is enabled & required
+    if (this.plugin.getConfig().get("settings.slack-link.enabled", false).equals(true)
+        && this.plugin.getConfig().get("settings.slack-link.required", false).equals(true)) {
+      // Check for slack link
+      if (data == null || data.getSlackId() == null) {
+        this.plugin.getLogger()
+            .info("Kicking " + player.getName() + " because they are not linked");
+        String code = this.plugin.getSlackBot()
+            .generateVerificationCode(player.getUniqueId().toString());
+        player.kick(text("You must link your Slack account to join the server!").color(RED)
+            .decorate(BOLD).appendNewline().appendNewline().append(
+                text("Please run ").color(NamedTextColor.WHITE)
+                    .append(text("/" + this.plugin.getConfig()
+                        .get("settings.slack-link.base-command", "minecraft") + " link "
+                        + code).color(NamedTextColor.GOLD))
+                    .append(text(
+                        " in the #minecraft channel in the Slack (https://slack.hackclub.com) to link your account."))
+                    .color(NamedTextColor.WHITE)));
+        return;
+      }
     }
 
     // Set the initial active time

--- a/src/main/java/com/hackclub/hccore/listeners/PlayerListener.java
+++ b/src/main/java/com/hackclub/hccore/listeners/PlayerListener.java
@@ -11,6 +11,7 @@ import com.hackclub.hccore.playerMessages.WelcomeMessage;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.BanEntry;
 import org.bukkit.BanList.Type;
@@ -115,7 +116,12 @@ public class PlayerListener implements Listener {
                         + code).color(NamedTextColor.GOLD))
                     .append(text(
                         " in the #minecraft channel in the Slack (https://slack.hackclub.com) to link your account."))
-                    .color(NamedTextColor.WHITE)));
+                    .color(NamedTextColor.WHITE)).appendNewline().appendNewline().append(
+                text("This code will expire after ").append(text(
+                        this.plugin.getConfig()
+                            .getInt("settings.slack-link.link-code-expiration", 60 * 10) + " seconds"))
+                    .append(text(".")).color(NamedTextColor.WHITE).decorate(
+                        TextDecoration.ITALIC)));
         return;
       }
     }

--- a/src/main/java/com/hackclub/hccore/listeners/PlayerListener.java
+++ b/src/main/java/com/hackclub/hccore/listeners/PlayerListener.java
@@ -106,7 +106,7 @@ public class PlayerListener implements Listener {
           .decorate(BOLD).appendNewline().appendNewline().append(
               text("Please run ").color(NamedTextColor.WHITE)
                   .append(text("/" + this.plugin.getConfig().get("settings.slack-link.base-command", "minecraft") + " link " + code).color(NamedTextColor.GOLD))
-                  .append(text(" in the #minecraft channel in the Slack to link your account.")).color(NamedTextColor.WHITE)));
+                  .append(text(" in the #minecraft channel in the Slack (https://slack.hackclub.com) to link your account.")).color(NamedTextColor.WHITE)));
       return;
     }
 

--- a/src/main/java/com/hackclub/hccore/listeners/PlayerListener.java
+++ b/src/main/java/com/hackclub/hccore/listeners/PlayerListener.java
@@ -99,8 +99,8 @@ public class PlayerListener implements Listener {
     PlayerData data = this.plugin.getDataManager().getData(player);
 
     // Check if slack link is enabled & required
-    if (this.plugin.getConfig().get("settings.slack-link.enabled", false).equals(true)
-        && this.plugin.getConfig().get("settings.slack-link.required", false).equals(true)) {
+    if (this.plugin.getConfig().getBoolean("settings.slack-link.enabled", false)
+        && this.plugin.getConfig().getBoolean("settings.slack-link.required", false)) {
       // Check for slack link
       if (data == null || data.getSlackId() == null) {
         this.plugin.getLogger()

--- a/src/main/java/com/hackclub/hccore/listeners/PlayerListener.java
+++ b/src/main/java/com/hackclub/hccore/listeners/PlayerListener.java
@@ -106,7 +106,7 @@ public class PlayerListener implements Listener {
         this.plugin.getLogger()
             .info("Kicking " + player.getName() + " because they are not linked");
         String code = this.plugin.getSlackBot()
-            .generateVerificationCode(player.getUniqueId().toString());
+            .generateVerificationCode(player.getUniqueId());
         player.kick(text("You must link your Slack account to join the server!").color(RED)
             .decorate(BOLD).appendNewline().appendNewline().append(
                 text("Please run ").color(NamedTextColor.WHITE)

--- a/src/main/java/com/hackclub/hccore/listeners/PlayerListener.java
+++ b/src/main/java/com/hackclub/hccore/listeners/PlayerListener.java
@@ -96,6 +96,20 @@ public class PlayerListener implements Listener {
   public void onPlayerJoin(final PlayerJoinEvent event) {
     Player player = event.getPlayer();
     this.plugin.getDataManager().registerPlayer(player);
+    PlayerData data = this.plugin.getDataManager().getData(player);
+
+    // Check for slack link
+    if (data == null || data.getSlackId() == null) {
+      this.plugin.getLogger().info("Kicking " + player.getName() + " because they are not linked");
+      String code = this.plugin.getSlackBot().generateVerificationCode(player.getUniqueId().toString());
+      player.kick(text("You must link your Slack account to join the server!").color(RED)
+          .decorate(BOLD).appendNewline().appendNewline().append(
+              text("Please run ").color(NamedTextColor.WHITE)
+                  .append(text("/" + this.plugin.getConfig().get("settings.slack-link.base-command", "minecraft") + " link " + code).color(NamedTextColor.GOLD))
+                  .append(text(" in the #minecraft channel in the Slack to link your account.")).color(NamedTextColor.WHITE)));
+      return;
+    }
+
     // Set the initial active time
     this.plugin.getDataManager().getData(player)
         .setLastActiveAt(System.currentTimeMillis());

--- a/src/main/java/com/hackclub/hccore/slack/SlackBot.java
+++ b/src/main/java/com/hackclub/hccore/slack/SlackBot.java
@@ -552,7 +552,12 @@ public class SlackBot implements Listener {
 
   public String generateVerificationCode(UUID mcUuid) {
     if (mcLinkCodes.containsKey(mcUuid)) {
-      return mcLinkCodes.get(mcUuid);
+      // refresh the time to live of the code
+      String code = mcLinkCodes.get(mcUuid);
+      mcLinkCodes.remove(mcUuid);
+      mcLinkCodes.put(mcUuid, code);
+
+      return code;
     } else {
       String code = UUID.randomUUID().toString().substring(0, 6);
       mcLinkCodes.put(mcUuid, code);

--- a/src/main/java/com/hackclub/hccore/slack/SlackBot.java
+++ b/src/main/java/com/hackclub/hccore/slack/SlackBot.java
@@ -76,7 +76,7 @@ public class SlackBot implements Listener {
   private final HCCorePlugin plugin;
   private final SocketModeApp socket;
   private final String commandBase;
-  private final HashMap<String, String> mcUuidVerificationCodes = new HashMap<>();
+  private final HashMap<UUID, String> mcUuidVerificationCodes = new HashMap<>();
 
   public SlackBot(HCCorePlugin plugin) throws Exception {
     this.plugin = plugin;
@@ -263,9 +263,9 @@ public class SlackBot implements Listener {
             .then(LiteralArgumentBuilder.<SlashCommandRequest>literal("link").then(RequiredArgumentBuilder.<SlashCommandRequest, String>argument("code",
                 StringArgumentType.greedyString()).executes(context -> {
               String code = StringArgumentType.getString(context, "code");
-              String mcUuid = null;
+              UUID mcUuid = null;
 
-              for (Entry<String, String> entry : mcUuidVerificationCodes.entrySet()) {
+              for (Entry<UUID, String> entry : mcUuidVerificationCodes.entrySet()) {
                 if (Objects.equals(code, entry.getValue())) {
                   mcUuid = entry.getKey();
                   break;
@@ -276,7 +276,7 @@ public class SlackBot implements Listener {
                 if (mcUuid == null) {
                   context.getSource().getContext().respond("Invalid code");
                 } else {
-                  OfflinePlayer player = Bukkit.getOfflinePlayer(UUID.fromString(mcUuid));
+                  OfflinePlayer player = Bukkit.getOfflinePlayer(mcUuid);
                   PlayerData data = this.plugin.getDataManager().getData(player);
 
                   if (data == null) {
@@ -549,7 +549,7 @@ public class SlackBot implements Listener {
     }
   }
 
-  public String generateVerificationCode(String mcUuid) {
+  public String generateVerificationCode(UUID mcUuid) {
     if (mcUuidVerificationCodes.containsKey(mcUuid)) {
       return mcUuidVerificationCodes.get(mcUuid);
     } else {

--- a/src/main/java/com/hackclub/hccore/slack/SlackBot.java
+++ b/src/main/java/com/hackclub/hccore/slack/SlackBot.java
@@ -298,7 +298,7 @@ public class SlackBot implements Listener {
 
                   // TODO: Make this message better to include rules and such
                   context.getSource().getContext().respond(
-                      "Successfully linked your minecraft account to your slack account! You may now join the server");
+                      "Successfully linked your minecraft account to your slack account! You may now join the server.");
 
                 }
                 return 1;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,6 +10,7 @@ settings:
     damage-cooldown: 10
   slack-link:
     enabled: false
+    required: false
     bot-token: ""
     app-token: ""
     channel-id: ""

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,9 +9,17 @@ settings:
     # Time in seconds a player has to wait before being able to use the command again
     damage-cooldown: 10
   slack-link:
+    # Whether the Slack integration is enabled
     enabled: false
+    # Whether to require a Slack link to join the server
     required: false
+    # Time in seconds after which the code will expire
+    link-code-expiration: 600
+    # The Slack bot token
     bot-token: ""
+    # The Slack app token
     app-token: ""
+    # The Slack channel ID to send Minecraft messages to and from
     channel-id: ""
+    # The base Slack command
     base-command: "minecraft"


### PR DESCRIPTION
This PR requires players to have their account linked to Slack before joining. This ensures that everyone playing on the server can be contacted by moderators, knows about the #minecraft channel, and is familiar with the rules and Hack Club Code of Conduct. Basically it is a Slack-only whitelist. 

It also adds a mechanism for linking your minecraft account to Slack before being able to join the game, so that new players can link their accounts. This is done by a link code in the kick message, which the player can then input to the added `/minecraft link` command in the slack bot, which will link their accounts.

UltimateAdvancementAPI is throwing errors when a player is kicked due to the fact that join events can't be cancelled and the event priority.

There's still a TODO message in there, about making the "your account is linked" message better, this will be done whenever a /rules command and/or a public place for rules and announcements (better than pinned messages) is made. Maybe the mc.hackclub.com website?

The DataManager and PlayerData was modified slightly to allow for data load/save while the player is offline, which was necessary for this feature.