### PR TITLE
Add safe Y level search to /spawn command to prevent traps/pits/etc

### DIFF
--- a/src/main/java/com/hackclub/hccore/commands/SpawnCommand.java
+++ b/src/main/java/com/hackclub/hccore/commands/SpawnCommand.java
@@ -89,7 +89,8 @@ public class SpawnCommand extends ArgumentlessCommand implements CommandExecutor
       int safeY = -1;
 
       // Search downward from the highest block to find a safe spawn point
-      for (int y = highestSpawnBlock.getY(); y > world.getMinHeight(); y--) {
+      // +1 cause we need to check the block above, not inside
+      for (int y = highestSpawnBlock.getY() + 1; y > world.getMinHeight(); y--) {
         Block blockAtY = world.getBlockAt(spawnX, y, spawnZ);
         Block blockBelow = world.getBlockAt(spawnX, y - 1, spawnZ);
         Block blockAbove = world.getBlockAt(spawnX, y + 1, spawnZ);


### PR DESCRIPTION
Adds a safe Y level search to /spawn command to prevent traps/pits/etc. If default Y level is unsafe, it searches downward from the highest block for a safe spawn location, if none found, defaults to default location. https://hackclub.slack.com/archives/CD1JSG9UK/p1762940072408239

Did not test since I could not get it running but should work fine 🙏 