### PR TITLE
Prevent Duplicate Nicknames

### DIFF
--- a/src/main/java/com/hackclub/hccore/commands/NickCommand.java
+++ b/src/main/java/com/hackclub/hccore/commands/NickCommand.java
@@ -3,6 +3,7 @@ package com.hackclub.hccore.commands;
 import com.hackclub.hccore.HCCorePlugin;
 import com.hackclub.hccore.PlayerData;
 import com.hackclub.hccore.playermessages.MustBePlayerMessage;
+import com.hackclub.hccore.playermessages.nickname.NicknameAlreadyUsedMessage;
 import com.hackclub.hccore.playermessages.nickname.NicknameLengthMessage;
 import com.hackclub.hccore.playermessages.nickname.NicknameResetMessage;
 import com.hackclub.hccore.playermessages.nickname.NicknameSetMessage;
@@ -41,6 +42,13 @@ public class NickCommand implements CommandExecutor {
       player.kick(SaharshMessage.get());
       return true;
     }
+
+    if (plugin.getDataManager().findData(data -> data.getNickname().equals(newNickname)) != null) {
+      sender.sendMessage(NicknameAlreadyUsedMessage.get(newNickname,
+        plugin.getDataManager().getData(player).getNameColor()));
+        return true;
+    }
+
 
     if (newNickname.length() > PlayerData.MAX_NICKNAME_LENGTH) {
       sender.sendMessage(NicknameLengthMessage.get(

--- a/src/main/java/com/hackclub/hccore/commands/NickCommand.java
+++ b/src/main/java/com/hackclub/hccore/commands/NickCommand.java
@@ -8,6 +8,7 @@ import com.hackclub.hccore.playermessages.nickname.NicknameLengthMessage;
 import com.hackclub.hccore.playermessages.nickname.NicknameResetMessage;
 import com.hackclub.hccore.playermessages.nickname.NicknameSetMessage;
 import com.hackclub.hccore.playermessages.nickname.SaharshMessage;
+import java.util.Objects;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -43,7 +44,7 @@ public class NickCommand implements CommandExecutor {
       return true;
     }
 
-    if (plugin.getDataManager().findData(data -> data.getNickname().equals(newNickname)) != null) {
+    if (plugin.getDataManager().findData(data -> Objects.equals(data.getNickname(), newNickname)) != null) {
       sender.sendMessage(NicknameAlreadyUsedMessage.get(newNickname,
         plugin.getDataManager().getData(player).getNameColor()));
         return true;

--- a/src/main/java/com/hackclub/hccore/playermessages/nickname/NicknameAlreadyUsedMessage.java
+++ b/src/main/java/com/hackclub/hccore/playermessages/nickname/NicknameAlreadyUsedMessage.java
@@ -1,0 +1,19 @@
+package com.hackclub.hccore.playermessages.nickname;
+
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.minimessage.MiniMessage.miniMessage;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+
+public class NicknameAlreadyUsedMessage {
+    final static String minimsgSource = """
+        <red>The nickname <nickname> is already in use.</red>""";
+
+  public static Component get(String nickname, TextColor color) {
+    return miniMessage().deserialize(minimsgSource, TagResolver.resolver(
+        Placeholder.component("nickname", text(nickname).color(color))));
+  }
+}


### PR DESCRIPTION
Don't let multiple people have the same nicknames, because this has been used for impersonation