### PR TITLE
Make the Shrimp Shuffler integration follow redirects

### DIFF
--- a/src/main/java/com/hackclub/hccore/tasks/IconTask.java
+++ b/src/main/java/com/hackclub/hccore/tasks/IconTask.java
@@ -20,7 +20,9 @@ public class IconTask implements Runnable {
   private final HttpClient client;
   public IconTask(HCCorePlugin plugin) {
     this.plugin = plugin;
-    this.client = HttpClient.newHttpClient();
+    this.client = HttpClient.newBuilder()
+        .followRedirects(HttpClient.Redirect.ALWAYS)
+        .build();
   }
 
   @Override


### PR DESCRIPTION
the new cdn uses a redirect to the final image, which the http client errors on. this makes it follow the redirects and get the proper image.