### PR TITLE
fix: spawn location y upper bound

### DIFF
--- a/src/main/java/com/hackclub/hccore/commands/SpawnCommand.java
+++ b/src/main/java/com/hackclub/hccore/commands/SpawnCommand.java
@@ -91,6 +91,7 @@ public class SpawnCommand extends ArgumentlessCommand implements CommandExecutor
       // Search downward from the highest block to find a safe spawn point
       // +1 cause we need to check the block above, not inside
       for (int y = highestSpawnBlock.getY() + 1; y > world.getMinHeight(); y--) {
+        if (y > (int) world.getSpawnLocation().getY()) continue;
         Block blockAtY = world.getBlockAt(spawnX, y, spawnZ);
         Block blockBelow = world.getBlockAt(spawnX, y - 1, spawnZ);
         Block blockAbove = world.getBlockAt(spawnX, y + 1, spawnZ);

--- a/src/main/java/com/hackclub/hccore/commands/SpawnCommand.java
+++ b/src/main/java/com/hackclub/hccore/commands/SpawnCommand.java
@@ -86,12 +86,13 @@ public class SpawnCommand extends ArgumentlessCommand implements CommandExecutor
 
       // Finds a safe spawn location near the world spawn to counter holes/pits/etc
       Block highestSpawnBlock = world.getHighestBlockAt(spawnX, spawnZ);
+      int highestSpawnY = world.getSpawnLocation().getBlockY();
       int safeY = -1;
 
       // Search downward from the highest block to find a safe spawn point
       // +1 cause we need to check the block above, not inside
       for (int y = highestSpawnBlock.getY() + 1; y > world.getMinHeight(); y--) {
-        if (y > (int) world.getSpawnLocation().getY()) continue;
+        if (y > highestSpawnY) continue;
         Block blockAtY = world.getBlockAt(spawnX, y, spawnZ);
         Block blockBelow = world.getBlockAt(spawnX, y - 1, spawnZ);
         Block blockAbove = world.getBlockAt(spawnX, y + 1, spawnZ);


### PR DESCRIPTION
the spawn y level in v1.18.2 (for `/spawn`) is based on the highest overall block, meaning it will spawn on top of structures if spawn is covered. this makes the check skip blocks above the spawnpoint y level.