### PR TITLE
Fix Slack Minecraft account integration

### DIFF
--- a/src/main/java/com/hackclub/hccore/DataManager.java
+++ b/src/main/java/com/hackclub/hccore/DataManager.java
@@ -2,9 +2,12 @@ package com.hackclub.hccore;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Predicate;
+import java.util.logging.Level;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.scoreboard.Scoreboard;
@@ -43,7 +46,39 @@ public class DataManager {
   }
 
   public PlayerData findData(Predicate<? super PlayerData> predicate) {
-    return this.onlinePlayers.values().stream().filter(predicate).findFirst().orElse(null);
+    PlayerData onlineMatch = this.onlinePlayers.values().stream().filter(predicate).findFirst()
+        .orElse(null);
+    if (onlineMatch != null) {
+      return onlineMatch;
+    }
+
+    File[] files = new File(this.dataFolder).listFiles(
+        (directory, name) -> name.endsWith(".json"));
+    if (files == null) {
+      return null;
+    }
+
+    Set<UUID> onlineUuids = new HashSet<>(this.onlinePlayers.keySet());
+    for (File file : files) {
+      String filename = file.getName();
+      try {
+        UUID uuid = UUID.fromString(filename.substring(0, filename.length() - ".json".length()));
+        if (onlineUuids.contains(uuid)) {
+          continue;
+        }
+
+        PlayerData data = this.getData(this.plugin.getServer().getOfflinePlayer(uuid));
+        data.load();
+        if (predicate.test(data)) {
+          return data;
+        }
+      } catch (IllegalArgumentException exception) {
+        this.plugin.getLogger().log(Level.WARNING,
+            "Ignoring player data file with an invalid UUID: " + filename);
+      }
+    }
+
+    return null;
   }
 
   public void registerPlayer(Player player) {

--- a/src/main/java/com/hackclub/hccore/listeners/PlayerListener.java
+++ b/src/main/java/com/hackclub/hccore/listeners/PlayerListener.java
@@ -136,7 +136,7 @@ public class PlayerListener implements Listener {
     return MustLinkMessage.get(baseCommand, code, codeExpires);
   }
 
-  @EventHandler(priority = EventPriority.MONITOR)
+  @EventHandler(priority = EventPriority.HIGHEST)
   public void onJoin(final PlayerJoinEvent event) {
     Player player = event.getPlayer();
     this.plugin.getDataManager().registerPlayer(player);

--- a/src/main/java/com/hackclub/hccore/slack/SlackBot.java
+++ b/src/main/java/com/hackclub/hccore/slack/SlackBot.java
@@ -61,7 +61,6 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerAdvancementDoneEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
-import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 public class SlackBot implements Listener {
@@ -212,33 +211,48 @@ public class SlackBot implements Listener {
                 })).then(LiteralArgumentBuilder.<SlashCommandRequest>literal("lookup")
                 .then(RequiredArgumentBuilder.<SlashCommandRequest, String>argument("mention",
                     StringArgumentType.greedyString()).executes(context -> {
-                  String mention = StringArgumentType.getString(context, "mention");
+                  String query = StringArgumentType.getString(context, "mention").trim();
                   String id;
 
                   // User mention
-                  if (mention.startsWith("<@") && mention.endsWith(">")) {
-                    int pipeIdx = mention.indexOf('|');
+                  if (query.startsWith("<@") && query.endsWith(">")) {
+                    int pipeIdx = query.indexOf('|');
                     if (pipeIdx == -1) {
-                      id = mention.substring(2, mention.length() - 1);
+                      id = query.substring(2, query.length() - 1);
                     } else {
-                      id = mention.substring(2, pipeIdx);
+                      id = query.substring(2, pipeIdx);
                     }
                   } else {
                     // Try user id
-                    id = mention;
+                    id = query;
                   }
 
                   try {
                     PlayerData data = this.plugin.getDataManager()
-                        .findData(pData -> pData.getSlackId().equals(id));
+                        .findData(pData -> Objects.equals(pData.getSlackId(), id));
 
-                    if (data == null) {
-                      context.getSource().getContext().respond("No linked user was found");
+                    if (data != null) {
+                      context.getSource().getContext().respond(
+                          "<@%s> is linked to the Minecraft account *%s* (`%s`).".formatted(
+                              id, data.getUsableName(), data.offlinePlayer.getName()));
+                      return 1;
+                    }
+
+                    data = this.plugin.getDataManager().findData(
+                        pData -> pData.offlinePlayer.getName() != null && (
+                            pData.offlinePlayer.getName().equalsIgnoreCase(query)
+                                || pData.getUsableName().equalsIgnoreCase(query)));
+
+                    if (data == null || data.getSlackId() == null) {
+                      context.getSource().getContext().respond(
+                          "No linked Slack or Minecraft account was found for `%s`.".formatted(
+                              query));
                       return 1;
                     }
 
                     context.getSource().getContext().respond(
-                        "The linked user is %s".formatted(data.getUsableName()));
+                        "Minecraft account *%s* (`%s`) is linked to <@%s>.".formatted(
+                            data.getUsableName(), data.offlinePlayer.getName(), data.getSlackId()));
                   } catch (IOException e) {
                     e.printStackTrace();
                   }
@@ -346,9 +360,10 @@ public class SlackBot implements Listener {
     sendMessage(":large_green_circle: *Server Started*", serverConsoleAvatarUrl, "Console");
   }
 
-  @Contract(pure = true)
   public static @NotNull String getPlayerAvatarLink(String uuid) {
-    return "https://cravatar.eu/avatar/" + uuid + "/512";
+    // Slack caches icon_url values aggressively. A changing query parameter makes it request the
+    // player's current skin instead of permanently reusing the first image it saw for this UUID.
+    return "https://cravatar.eu/avatar/" + uuid + "/512?cache=" + System.currentTimeMillis();
   }
 
   public void disconnect() throws Exception {
@@ -373,7 +388,8 @@ public class SlackBot implements Listener {
         return;
       }
     }
-    sendMessage("*" + plainText().serialize(player.displayName()) + "* joined the game!",
+    PlayerData data = plugin.getDataManager().getData(player);
+    sendMessage("*" + plainText().serialize(data.getDisplayedName()) + "* joined the game!",
         playerServerJoinAvatarUrl, "Join");
   }
 


### PR DESCRIPTION
This should fix: updating profile pictures, join messages not showing the customised alias, and /minecraft lookup. (i figured out why that doesn't work btw, it's because it only works if the targeted player is currently online on the server)