### PR TITLE
update slack bot so & works in chat

### DIFF
--- a/src/main/java/com/hackclub/hccore/playermessages/slack/SlackChatMessage.java
+++ b/src/main/java/com/hackclub/hccore/playermessages/slack/SlackChatMessage.java
@@ -1,7 +1,6 @@
 package com.hackclub.hccore.playermessages.slack;
 
 import static net.kyori.adventure.text.minimessage.MiniMessage.miniMessage;
-import static net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacyAmpersand;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
@@ -15,6 +14,6 @@ public class SlackChatMessage {
   public static Component get(Component playerComponent, String message) {
     return miniMessage().deserialize(minimsgSource,
         TagResolver.resolver(Placeholder.component("playercomponent", playerComponent),
-            Placeholder.component("message", legacyAmpersand().deserialize(message))));
+            Placeholder.component("message", Component.text(message))));
   }
 }

--- a/src/main/java/com/hackclub/hccore/slack/SlackBot.java
+++ b/src/main/java/com/hackclub/hccore/slack/SlackBot.java
@@ -48,6 +48,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.collections4.map.PassiveExpiringMap;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
@@ -88,9 +89,7 @@ public class SlackBot implements Listener {
     Pattern sdk = Pattern.compile(".*");
     app.message(sdk, (payload, ctx) -> {
       MessageEvent event = payload.getEvent();
-      // Weird bug with this right now...
-      // String text = StringEscapeUtils.unescapeHtml4(event.getText());
-      String text = event.getText();
+      String text = StringEscapeUtils.unescapeHtml4(event.getText());
       String channelId = event.getChannel();
       String mainChannel = getSlackChannel();
       if (!channelId.equals(mainChannel)) {


### PR DESCRIPTION
Currently, it is stripping the &a from &amp; and then using it as a format code. This fixes typing symbols in slack chat.
<img width="321" height="60" alt="Screenshot 2026-08-13 at 12 01 30 am" src="https://github.com/user-attachments/assets/3952df6f-0849-49bd-8ebd-bc2e63d58f75" />
<img width="827" height="38" alt="Screenshot 2026-08-13 at 12 01 39 am" src="https://github.com/user-attachments/assets/382baa45-b4ca-4c06-8251-8705d838c073" />
